### PR TITLE
Timesave Column

### DIFF
--- a/UI/ColumnType.cs
+++ b/UI/ColumnType.cs
@@ -2,6 +2,6 @@
 {
     public enum ColumnType
     {
-        Delta, SplitTime, DeltaorSplitTime, SegmentDelta, SegmentTime, SegmentDeltaorSegmentTime, SegmentTimeSave
+        Delta, SplitTime, DeltaorSplitTime, SegmentDelta, SegmentTime, SegmentDeltaorSegmentTime, SegmentPossibleTimeSave
     }
 }

--- a/UI/ColumnType.cs
+++ b/UI/ColumnType.cs
@@ -2,6 +2,6 @@
 {
     public enum ColumnType
     {
-        Delta, SplitTime, DeltaorSplitTime, SegmentDelta, SegmentTime, SegmentDeltaorSegmentTime
+        Delta, SplitTime, DeltaorSplitTime, SegmentDelta, SegmentTime, SegmentDeltaorSegmentTime, SegmentTimeSave
     }
 }

--- a/UI/Components/ColumnSettings.Designer.cs
+++ b/UI/Components/ColumnSettings.Designer.cs
@@ -137,7 +137,8 @@
             "Delta or Split Time",
             "Segment Delta",
             "Segment Time",
-            "Segment Delta or Segment Time"});
+            "Segment Delta or Segment Time",
+            "Segment Time Save"});
             this.cmbColumnType.Location = new System.Drawing.Point(93, 33);
             this.cmbColumnType.Name = "cmbColumnType";
             this.cmbColumnType.Size = new System.Drawing.Size(325, 21);

--- a/UI/Components/ColumnSettings.Designer.cs
+++ b/UI/Components/ColumnSettings.Designer.cs
@@ -138,7 +138,7 @@
             "Segment Delta",
             "Segment Time",
             "Segment Delta or Segment Time",
-            "Segment Time Save"});
+            "Segment Possible Time Save"});
             this.cmbColumnType.Location = new System.Drawing.Point(93, 33);
             this.cmbColumnType.Name = "cmbColumnType";
             this.cmbColumnType.Size = new System.Drawing.Size(325, 21);

--- a/UI/Components/ColumnSettings.cs
+++ b/UI/Components/ColumnSettings.cs
@@ -114,7 +114,7 @@ namespace LiveSplit.UI.Components
                 return "Segment Time";
             else if (type == ColumnType.SegmentDelta)
                 return "Segment Delta";
-            else if (type == ColumnType.SegmentTimeSave)
+            else if (type == ColumnType.SegmentPossibleTimeSave)
                 return "Segment Possible Time Save";
             else
                 return "Segment Delta or Segment Time";

--- a/UI/Components/ColumnSettings.cs
+++ b/UI/Components/ColumnSettings.cs
@@ -114,6 +114,8 @@ namespace LiveSplit.UI.Components
                 return "Segment Time";
             else if (type == ColumnType.SegmentDelta)
                 return "Segment Delta";
+            else if (type == ColumnType.SegmentTimeSave)
+                return "Segment Possible Time Save";
             else
                 return "Segment Delta or Segment Time";
         }

--- a/UI/Components/SplitComponent.cs
+++ b/UI/Components/SplitComponent.cs
@@ -487,8 +487,14 @@ namespace LiveSplit.UI.Components
                         }
                     }
 
-                    // it doesn't seem like this live-updates.. hm.
-                    var time = Split.Comparisons[comparison][state.CurrentTimingMethod] - prevTime - bestSegments;
+                    var time = Split.Comparisons[comparison][timingMethod] - prevTime - bestSegments;
+
+                    if (splitIndex == state.CurrentSplitIndex)
+                    {
+                        var segmentDelta = TimeSpan.Zero - LiveSplitStateHelper.GetLiveSegmentDelta(state, splitIndex, comparison, timingMethod);
+                        if (segmentDelta < time)
+                            time = segmentDelta;
+                    }
 
                     if (time < TimeSpan.Zero)
                         time = TimeSpan.Zero;

--- a/UI/Components/SplitComponent.cs
+++ b/UI/Components/SplitComponent.cs
@@ -496,8 +496,6 @@ namespace LiveSplit.UI.Components
                             time = segmentDelta;
                     }
 
-                    if (time < TimeSpan.Zero)
-                        time = TimeSpan.Zero;
                     if (time.HasValue)
                         time = time.Value.Negate();
 

--- a/UI/Components/SplitComponent.cs
+++ b/UI/Components/SplitComponent.cs
@@ -404,7 +404,7 @@ namespace LiveSplit.UI.Components
                     }
                 }
                 
-                if (type == ColumnType.DeltaorSplitTime || type == ColumnType.Delta)
+                else if (type == ColumnType.DeltaorSplitTime || type == ColumnType.Delta)
                 {
                     var deltaTime = Split.SplitTime[timingMethod] - Split.Comparisons[comparison][timingMethod];
                     var color = LiveSplitStateHelper.GetSplitColor(state, deltaTime, splitIndex, true, true, comparison, timingMethod);

--- a/UI/Components/SplitComponent.cs
+++ b/UI/Components/SplitComponent.cs
@@ -416,7 +416,7 @@ namespace LiveSplit.UI.Components
                     }
                 }
 
-                else if (type == ColumnType.SegmentTimeSave)
+                else if (type == ColumnType.SegmentPossibleTimeSave)
                 {
                     TimeSpan? previousTime = splitIndex > 0 ? state.Run[splitIndex - 1].Comparisons[comparison][timingMethod] : TimeSpan.Zero;
                     TimeSpan? time = state.Run[splitIndex].Comparisons[comparison][timingMethod] - previousTime; //state.Run[splitIndex].BestSegmentTime[state.CurrentTimingMethod];
@@ -467,7 +467,7 @@ namespace LiveSplit.UI.Components
                     label.Text = "";
                 }
 
-                if (type == ColumnType.SegmentTimeSave)
+                if (type == ColumnType.SegmentPossibleTimeSave)
                 {
                     var prevTime = TimeSpan.Zero;
                     TimeSpan? bestSegments = state.Run[splitIndex].BestSegmentTime[timingMethod];

--- a/UI/Components/SplitComponent.cs
+++ b/UI/Components/SplitComponent.cs
@@ -357,7 +357,37 @@ namespace LiveSplit.UI.Components
             var type = data.Type;
 
             var splitIndex = state.Run.IndexOf(Split);
-            if (splitIndex < state.CurrentSplitIndex)
+
+            // Segment Possible Time Save
+            if (type == ColumnType.SegmentTimeSave)
+            {
+                var prevTime = TimeSpan.Zero;
+                TimeSpan? bestSegments = state.Run[splitIndex].BestSegmentTime[state.CurrentTimingMethod];
+
+                while (splitIndex > 0 && bestSegments != null)
+                {
+                    var splitTime = state.Run[splitIndex - 1].Comparisons[comparison][state.CurrentTimingMethod];
+                    if (splitTime != null)
+                    {
+                        prevTime = splitTime.Value;
+                        break;
+                    }
+                    else
+                    {
+                        splitIndex--;
+                        bestSegments += state.Run[splitIndex].BestSegmentTime[state.CurrentTimingMethod];
+                    }
+                }
+
+                var time = Split.Comparisons[comparison][state.CurrentTimingMethod] - prevTime - bestSegments;
+
+                if (time < TimeSpan.Zero)
+                    time = TimeSpan.Zero;
+
+                label.ForeColor = state.LayoutSettings.TextColor;
+                label.Text = DeltaTimeFormatter.Format(time);
+            }
+            else if (splitIndex < state.CurrentSplitIndex)
             {
                 if (type == ColumnType.SplitTime || type == ColumnType.SegmentTime)
                 {

--- a/UI/Components/SplitComponent.cs
+++ b/UI/Components/SplitComponent.cs
@@ -419,7 +419,7 @@ namespace LiveSplit.UI.Components
                 else if (type == ColumnType.SegmentTimeSave)
                 {
                     TimeSpan? previousTime = splitIndex > 0 ? state.Run[splitIndex - 1].Comparisons[comparison][timingMethod] : TimeSpan.Zero;
-                    TimeSpan? time = state.Run[splitIndex].Comparisons[comparison][state.CurrentTimingMethod] - previousTime; //state.Run[splitIndex].BestSegmentTime[state.CurrentTimingMethod];
+                    TimeSpan? time = state.Run[splitIndex].Comparisons[comparison][timingMethod] - previousTime; //state.Run[splitIndex].BestSegmentTime[state.CurrentTimingMethod];
                     TimeSpan? time2 = LiveSplitStateHelper.GetPreviousSegmentTime(state, splitIndex, comparison, timingMethod);
 
                     label.ForeColor = state.LayoutSettings.PausedColor; // should we reuse a color? hm..
@@ -470,11 +470,11 @@ namespace LiveSplit.UI.Components
                 if (type == ColumnType.SegmentTimeSave)
                 {
                     var prevTime = TimeSpan.Zero;
-                    TimeSpan? bestSegments = state.Run[splitIndex].BestSegmentTime[state.CurrentTimingMethod];
+                    TimeSpan? bestSegments = state.Run[splitIndex].BestSegmentTime[timingMethod];
 
                     while (splitIndex > 0 && bestSegments != null)
                     {
-                        var splitTime = state.Run[splitIndex - 1].Comparisons[comparison][state.CurrentTimingMethod];
+                        var splitTime = state.Run[splitIndex - 1].Comparisons[comparison][timingMethod];
                         if (splitTime != null)
                         {
                             prevTime = splitTime.Value;
@@ -483,7 +483,7 @@ namespace LiveSplit.UI.Components
                         else
                         {
                             splitIndex--; // variable mangling
-                            bestSegments += state.Run[splitIndex].BestSegmentTime[state.CurrentTimingMethod];
+                            bestSegments += state.Run[splitIndex].BestSegmentTime[timingMethod];
                         }
                     }
 


### PR DESCRIPTION
I made "Possible Time Save" a column.

It looks like this for segments you haven't completed yet. It shows the difference between your selected comparison and your segment best - exactly the same as the Possible Time Save component, but for every segment instead of only the current.
![image](https://cloud.githubusercontent.com/assets/716157/11020019/936ac504-85c6-11e5-9b0b-0bd64e1ae787.png)

Once you finish a segment, it turns grey and shows how much time you ended up saving (or losing) over your selected comparison.
![image](https://cloud.githubusercontent.com/assets/716157/11020020/aaaf37c2-85c6-11e5-9451-241dbe46e3c5.png)

Updates live for the current segment.
