### PR TITLE
Make internals visible for unit tests

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -38,4 +38,3 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
 [assembly: ComponentFactory(typeof(SplitsComponentFactory))]
-[assembly: InternalsVisibleTo("LiveSplit.UnitTests")]

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -38,3 +38,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
 [assembly: ComponentFactory(typeof(SplitsComponentFactory))]
+[assembly: InternalsVisibleTo("LiveSplit.UnitTests")]

--- a/TimeFormatters/DeltaSplitTimeFormatter.cs
+++ b/TimeFormatters/DeltaSplitTimeFormatter.cs
@@ -2,7 +2,7 @@
 
 namespace LiveSplit.TimeFormatters
 {
-    class DeltaSplitTimeFormatter : ITimeFormatter
+    public class DeltaSplitTimeFormatter : ITimeFormatter
     {
         public TimeAccuracy Accuracy { get; set; }
         public bool DropDecimals { get; set; }

--- a/TimeFormatters/RegularSplitTimeFormatter.cs
+++ b/TimeFormatters/RegularSplitTimeFormatter.cs
@@ -2,7 +2,7 @@
 
 namespace LiveSplit.TimeFormatters
 {
-    class RegularSplitTimeFormatter : ITimeFormatter
+    public class RegularSplitTimeFormatter : ITimeFormatter
     {
         public TimeAccuracy Accuracy { get; set; }
 


### PR DESCRIPTION
Allow unit tests to be created for all TimeFormatters. See: https://github.com/LiveSplit/LiveSplit/pull/1446