### PR TITLE
Add ability to dynamically replace a comparison label text with the current comparison

### DIFF
--- a/UI/Components/LabelsComponent.cs
+++ b/UI/Components/LabelsComponent.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
+using LiveSplit.Model.Comparisons;
 
 namespace LiveSplit.UI.Components
 {
@@ -178,6 +179,10 @@ namespace LiveSplit.UI.Components
             {
                 var column = ColumnsList.ElementAt(LabelsList.IndexOf(label));
                 label.Text = column.Name;
+                if(column.Name.Equals("Current Comparison"))
+                {
+                    label.Text = CompositeComparisons.GetShortComparisonName(state.CurrentComparison);
+                }
                 label.ForeColor = Settings.LabelsColor;
             }
         }


### PR DESCRIPTION
Add ability to dynamically replace a comparison label text with the current comparison by naming it "Current Comparison" exactly.