### PR TITLE
Use the comparison name by default

### DIFF
--- a/UI/Components/LabelsComponent.cs
+++ b/UI/Components/LabelsComponent.cs
@@ -179,13 +179,7 @@ namespace LiveSplit.UI.Components
             {
                 var column = ColumnsList.ElementAt(LabelsList.IndexOf(label));
                 if (String.IsNullOrEmpty(column.Name))
-                {
-                    string comparison = column.Comparison == "Current Comparison" ? state.CurrentComparison : column.Comparison;
-                    if (comparison.StartsWith("[Race] "))
-                        label.Text = comparison.Substring(7);
-                    else
-                        label.Text = CompositeComparisons.GetShortComparisonName(comparison);
-                }
+                    label.Text = CompositeComparisons.GetShortComparisonName(column.Comparison == "Current Comparison" ? state.CurrentComparison : column.Comparison);
                 else
                     label.Text = column.Name;
                 label.ForeColor = Settings.LabelsColor;

--- a/UI/Components/LabelsComponent.cs
+++ b/UI/Components/LabelsComponent.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
+using LiveSplit.Model.Comparisons;
 
 namespace LiveSplit.UI.Components
 {
@@ -177,7 +178,16 @@ namespace LiveSplit.UI.Components
             foreach (var label in LabelsList)
             {
                 var column = ColumnsList.ElementAt(LabelsList.IndexOf(label));
-                label.Text = column.Name;
+                if (String.IsNullOrEmpty(column.Name))
+                {
+                    string comparison = column.Comparison == "Current Comparison" ? state.CurrentComparison : column.Comparison;
+                    if (comparison.StartsWith("[Race] "))
+                        label.Text = comparison.Substring(7);
+                    else
+                        label.Text = CompositeComparisons.GetShortComparisonName(comparison);
+                }
+                else
+                    label.Text = column.Name;
                 label.ForeColor = Settings.LabelsColor;
             }
         }

--- a/UI/Components/SplitsSettings.cs
+++ b/UI/Components/SplitsSettings.cs
@@ -575,7 +575,7 @@ namespace LiveSplit.UI.Components
         {
             UpdateLayoutForColumn();
 
-            var columnControl = new ColumnSettings(CurrentState, "#" + (ColumnsList.Count + 1), ColumnsList);
+            var columnControl = new ColumnSettings(CurrentState, "", ColumnsList);
             ColumnsList.Add(columnControl);
             AddColumnToLayout(columnControl, ColumnsList.Count);
 


### PR DESCRIPTION
When the column name is blank, we use the comparison (short) name. This avoids the user to re-type the comparison name they already chose in the dropdown. In the case the column is comparing to current comparison, the label will nicely adapt to the actual comparison name. The user can still put a white space to have a blank column.
This is a generalization of #17 and a little cleaner way to do it.