### PR TITLE
ColumnType: CustomVariable

### DIFF
--- a/src/LiveSplit.Splits/UI/ColumnType.cs
+++ b/src/LiveSplit.Splits/UI/ColumnType.cs
@@ -2,5 +2,5 @@
 
 public enum ColumnType
 {
-    Delta, SplitTime, DeltaorSplitTime, SegmentDelta, SegmentTime, SegmentDeltaorSegmentTime
+    Delta, SplitTime, DeltaorSplitTime, SegmentDelta, SegmentTime, SegmentDeltaorSegmentTime, CustomVariable
 }

--- a/src/LiveSplit.Splits/UI/Components/ColumnSettings.Designer.cs
+++ b/src/LiveSplit.Splits/UI/Components/ColumnSettings.Designer.cs
@@ -137,7 +137,8 @@
             "Delta or Split Time",
             "Segment Delta",
             "Segment Time",
-            "Segment Delta or Segment Time"});
+            "Segment Delta or Segment Time",
+            "Custom Variable"});
             this.cmbColumnType.Location = new System.Drawing.Point(93, 33);
             this.cmbColumnType.Name = "cmbColumnType";
             this.cmbColumnType.Size = new System.Drawing.Size(325, 21);

--- a/src/LiveSplit.Splits/UI/Components/ColumnSettings.cs
+++ b/src/LiveSplit.Splits/UI/Components/ColumnSettings.cs
@@ -131,9 +131,17 @@ public partial class ColumnSettings : UserControl
         {
             return "Segment Delta";
         }
-        else
+        else if (type == ColumnType.SegmentDeltaorSegmentTime)
         {
             return "Segment Delta or Segment Time";
+        }
+        else if (type == ColumnType.CustomVariable)
+        {
+            return "Custom Variable";
+        }
+        else
+        {
+            return "Unknown";
         }
     }
 

--- a/src/LiveSplit.Splits/UI/Components/LabelsComponent.cs
+++ b/src/LiveSplit.Splits/UI/Components/LabelsComponent.cs
@@ -119,9 +119,13 @@ public class LabelsComponent : IComponent
                 {
                     labelWidth = MeasureDeltaLabel.ActualWidth;
                 }
-                else
+                else if (column.Type is ColumnType.SplitTime or ColumnType.SegmentTime)
                 {
                     labelWidth = MeasureTimeLabel.ActualWidth;
+                }
+                else if (column.Type is ColumnType.CustomVariable)
+                {
+                    labelWidth = Math.Max(MeasureDeltaLabel.ActualWidth, MeasureTimeLabel.ActualWidth);
                 }
 
                 curX -= labelWidth + 5;

--- a/src/LiveSplit.Splits/UI/Components/LabelsComponent.cs
+++ b/src/LiveSplit.Splits/UI/Components/LabelsComponent.cs
@@ -6,24 +6,12 @@ using System.Windows.Forms;
 
 using LiveSplit.Model;
 using LiveSplit.Model.Comparisons;
-using LiveSplit.TimeFormatters;
 
 namespace LiveSplit.UI.Components;
 
 public class LabelsComponent : IComponent
 {
     public SplitsSettings Settings { get; set; }
-
-    protected SimpleLabel MeasureTimeLabel { get; set; }
-    protected SimpleLabel MeasureDeltaLabel { get; set; }
-    protected SimpleLabel MeasureCharLabel { get; set; }
-
-    protected ITimeFormatter TimeFormatter { get; set; }
-    protected ITimeFormatter DeltaTimeFormatter { get; set; }
-
-    protected TimeAccuracy CurrentAccuracy { get; set; }
-    protected TimeAccuracy CurrentDeltaAccuracy { get; set; }
-    protected bool CurrentDropDecimals { get; set; }
 
     protected int FrameCount { get; set; }
 
@@ -52,12 +40,6 @@ public class LabelsComponent : IComponent
         Settings = settings;
         MinimumHeight = 31;
 
-        MeasureTimeLabel = new SimpleLabel();
-        MeasureDeltaLabel = new SimpleLabel();
-        MeasureCharLabel = new SimpleLabel();
-        TimeFormatter = new SplitTimeFormatter(Settings.SplitTimesAccuracy);
-        DeltaTimeFormatter = new DeltaSplitTimeFormatter(Settings.DeltasAccuracy, Settings.DropDecimals);
-
         Cache = new GraphicsCache();
         LabelsList = [];
         ColumnsList = columns;
@@ -71,34 +53,6 @@ public class LabelsComponent : IComponent
             g.FillRectangle(new SolidBrush(
                 Settings.BackgroundColor
                 ), 0, 0, width, height);
-        }
-
-        MeasureTimeLabel.Text = TimeFormatter.Format(new TimeSpan(24, 0, 0));
-        MeasureDeltaLabel.Text = DeltaTimeFormatter.Format(new TimeSpan(0, 9, 0, 0));
-        MeasureCharLabel.Text = "W";
-
-        MeasureTimeLabel.Font = state.LayoutSettings.TimesFont;
-        MeasureTimeLabel.IsMonospaced = true;
-        MeasureDeltaLabel.Font = state.LayoutSettings.TimesFont;
-        MeasureDeltaLabel.IsMonospaced = true;
-        MeasureCharLabel.Font = state.LayoutSettings.TimesFont;
-        MeasureCharLabel.IsMonospaced = true;
-
-        MeasureTimeLabel.SetActualWidth(g);
-        MeasureDeltaLabel.SetActualWidth(g);
-        MeasureCharLabel.SetActualWidth(g);
-
-        if (Settings.SplitTimesAccuracy != CurrentAccuracy)
-        {
-            TimeFormatter = new SplitTimeFormatter(Settings.SplitTimesAccuracy);
-            CurrentAccuracy = Settings.SplitTimesAccuracy;
-        }
-
-        if (Settings.DeltasAccuracy != CurrentDeltaAccuracy || Settings.DropDecimals != CurrentDropDecimals)
-        {
-            DeltaTimeFormatter = new DeltaSplitTimeFormatter(Settings.DeltasAccuracy, Settings.DropDecimals);
-            CurrentDeltaAccuracy = Settings.DeltasAccuracy;
-            CurrentDropDecimals = Settings.DropDecimals;
         }
 
         foreach (SimpleLabel label in LabelsList)
@@ -121,29 +75,7 @@ public class LabelsComponent : IComponent
             float curX = width - 7;
             foreach (SimpleLabel label in LabelsList.Reverse())
             {
-                int i = LabelsList.IndexOf(label);
-                ColumnData column = ColumnsList.ElementAt(i);
-
-                float labelWidth = 0f;
-                if (column.Type is ColumnType.DeltaorSplitTime or ColumnType.SegmentDeltaorSegmentTime)
-                {
-                    labelWidth = Math.Max(MeasureDeltaLabel.ActualWidth, MeasureTimeLabel.ActualWidth);
-                }
-                else if (column.Type is ColumnType.Delta or ColumnType.SegmentDelta)
-                {
-                    labelWidth = MeasureDeltaLabel.ActualWidth;
-                }
-                else if (column.Type is ColumnType.SplitTime or ColumnType.SegmentTime)
-                {
-                    labelWidth = MeasureTimeLabel.ActualWidth;
-                }
-                else if (column.Type is ColumnType.CustomVariable)
-                {
-                    labelWidth = MeasureCharLabel.ActualWidth;
-                }
-
-                labelWidth = Math.Max(ColumnWidths[i], labelWidth);
-                ColumnWidths[i] = labelWidth;
+                float labelWidth = ColumnWidths[LabelsList.IndexOf(label)];
 
                 curX -= labelWidth + 5;
                 label.Width = labelWidth;

--- a/src/LiveSplit.Splits/UI/Components/SplitComponent.cs
+++ b/src/LiveSplit.Splits/UI/Components/SplitComponent.cs
@@ -558,10 +558,15 @@ public class SplitComponent : IComponent
             Cache["IsActive"] = IsActive;
             Cache["NameColor"] = NameLabel.ForeColor.ToArgb();
             Cache["ColumnsCount"] = ColumnsList.Count();
-            foreach (SimpleLabel label in LabelsList)
+            for (int index = 0; index < LabelsList.Count; index++)
             {
-                Cache["Columns" + LabelsList.IndexOf(label) + "Text"] = label.Text;
-                Cache["Columns" + LabelsList.IndexOf(label) + "Color"] = label.ForeColor.ToArgb();
+                SimpleLabel label = LabelsList[index];
+                Cache["Columns" + index + "Text"] = label.Text;
+                Cache["Columns" + index + "Color"] = label.ForeColor.ToArgb();
+                if (index < ColumnWidths.Count)
+                {
+                    Cache["Columns" + index + "Width"] = ColumnWidths[index];
+                }
             }
 
             if (invalidator != null && (Cache.HasChanged || FrameCount > 1))

--- a/src/LiveSplit.Splits/UI/Components/SplitComponent.cs
+++ b/src/LiveSplit.Splits/UI/Components/SplitComponent.cs
@@ -244,9 +244,13 @@ public class SplitComponent : IComponent
                     {
                         labelWidth = MeasureDeltaLabel.ActualWidth;
                     }
-                    else
+                    else if (column.Type is ColumnType.SplitTime or ColumnType.SegmentTime)
                     {
                         labelWidth = MeasureTimeLabel.ActualWidth;
+                    }
+                    else if (column.Type is ColumnType.CustomVariable)
+                    {
+                        labelWidth = Math.Max(MeasureDeltaLabel.ActualWidth, MeasureTimeLabel.ActualWidth);
                     }
 
                     label.Width = labelWidth + 20;
@@ -497,6 +501,17 @@ public class SplitComponent : IComponent
 
                     label.Text = TimeFormatter.Format(Split.Comparisons[comparison][timingMethod] - previousTime);
                 }
+                else if (type is ColumnType.CustomVariable)
+                {
+                    if (splitIndex == state.CurrentSplitIndex)
+                    {
+                        label.Text = state.Run.Metadata.CustomVariableValue(data.Name) ?? "";
+                    }
+                    else if (splitIndex > state.CurrentSplitIndex)
+                    {
+                        label.Text = "";
+                    }
+                }
             }
 
             //Live Delta
@@ -512,17 +527,6 @@ public class SplitComponent : IComponent
             {
                 label.Text = "";
             }
-            else if (type is ColumnType.CustomVariable)
-            {
-                if (Split == state.CurrentSplit)
-                {
-                    label.Text = state.Run.Metadata.CustomVariableValue(data.Name) ?? "";
-                }
-                else
-                {
-                    label.Text = "";
-                }
-            }
         }
     }
 
@@ -533,9 +537,11 @@ public class SplitComponent : IComponent
             int mixedCount = ColumnsList.Count(x => x.Type is ColumnType.DeltaorSplitTime or ColumnType.SegmentDeltaorSegmentTime);
             int deltaCount = ColumnsList.Count(x => x.Type is ColumnType.Delta or ColumnType.SegmentDelta);
             int timeCount = ColumnsList.Count(x => x.Type is ColumnType.SplitTime or ColumnType.SegmentTime);
+            int varCount = ColumnsList.Count(x => x.Type is ColumnType.CustomVariable);
             return (mixedCount * (Math.Max(MeasureDeltaLabel.ActualWidth, MeasureTimeLabel.ActualWidth) + 5))
                 + (deltaCount * (MeasureDeltaLabel.ActualWidth + 5))
-                + (timeCount * (MeasureTimeLabel.ActualWidth + 5));
+                + (timeCount * (MeasureTimeLabel.ActualWidth + 5))
+                + (varCount * (Math.Max(MeasureDeltaLabel.ActualWidth, MeasureTimeLabel.ActualWidth) + 5));
         }
 
         return 0f;

--- a/src/LiveSplit.Splits/UI/Components/SplitComponent.cs
+++ b/src/LiveSplit.Splits/UI/Components/SplitComponent.cs
@@ -391,7 +391,7 @@ public class SplitComponent : IComponent
         int splitIndex = state.Run.IndexOf(Split);
         if (splitIndex < state.CurrentSplitIndex)
         {
-            if (type is ColumnType.SplitTime or ColumnType.SegmentTime)
+            if (type is ColumnType.SplitTime or ColumnType.SegmentTime or ColumnType.CustomVariable)
             {
                 label.ForeColor = Settings.OverrideTimesColor ? Settings.BeforeTimesColor : state.LayoutSettings.TextColor;
 
@@ -399,10 +399,15 @@ public class SplitComponent : IComponent
                 {
                     label.Text = TimeFormatter.Format(Split.SplitTime[timingMethod]);
                 }
-                else //SegmentTime
+                else if (type == ColumnType.SegmentTime)
                 {
                     TimeSpan? segmentTime = LiveSplitStateHelper.GetPreviousSegmentTime(state, splitIndex, timingMethod);
                     label.Text = TimeFormatter.Format(segmentTime);
+                }
+                else if (type == ColumnType.CustomVariable)
+                {
+                    Split.CustomVariableValues.TryGetValue(data.Name, out string text);
+                    label.Text = text ?? "";
                 }
             }
 
@@ -461,12 +466,6 @@ public class SplitComponent : IComponent
                 {
                     label.Text = DeltaTimeFormatter.Format(segmentDelta);
                 }
-            }
-
-            else if (type is ColumnType.CustomVariable)
-            {
-                Split.CustomVariableValues.TryGetValue(data.Name, out string text);
-                label.Text = text ?? "";
             }
         }
         else

--- a/src/LiveSplit.Splits/UI/Components/SplitComponent.cs
+++ b/src/LiveSplit.Splits/UI/Components/SplitComponent.cs
@@ -48,8 +48,6 @@ public class SplitComponent : IComponent
     public IEnumerable<ColumnData> ColumnsList { get; set; }
     public IList<SimpleLabel> LabelsList { get; set; }
 
-    protected IList<Dictionary<string, string>> CustomVariableValues { get; }
-
     public float VerticalHeight { get; set; }
 
     public float MinimumWidth
@@ -62,7 +60,7 @@ public class SplitComponent : IComponent
 
     public IDictionary<string, Action> ContextMenuControls => null;
 
-    public SplitComponent(SplitsSettings settings, IEnumerable<ColumnData> columnsList, IList<Dictionary<string, string>> customVariableValues)
+    public SplitComponent(SplitsSettings settings, IEnumerable<ColumnData> columnsList)
     {
         NameLabel = new SimpleLabel()
         {
@@ -73,7 +71,6 @@ public class SplitComponent : IComponent
         MeasureDeltaLabel = new SimpleLabel();
         Settings = settings;
         ColumnsList = columnsList;
-        CustomVariableValues = customVariableValues;
         TimeFormatter = new SplitTimeFormatter(Settings.SplitTimesAccuracy);
         DeltaTimeFormatter = new DeltaSplitTimeFormatter(Settings.DeltasAccuracy, Settings.DropDecimals);
         MinimumHeight = 25;
@@ -468,11 +465,10 @@ public class SplitComponent : IComponent
                 if (Split.SplitTime[timingMethod] == null)
                 {
                     label.Text = "";
-                    CustomVariableValues[splitIndex].Clear();
                 }
                 else
                 {
-                    CustomVariableValues[splitIndex].TryGetValue(data.Name, out string text);
+                    Split.CustomVariableValues.TryGetValue(data.Name, out string text);
                     label.Text = text ?? "";
                 }
             }
@@ -528,8 +524,7 @@ public class SplitComponent : IComponent
             {
                 if (Split == state.CurrentSplit)
                 {
-                    CustomVariableValues[splitIndex].TryGetValue(data.Name, out string text);
-                    label.Text = text ?? "";
+                    label.Text = state.Run.Metadata.CustomVariableValue(data.Name) ?? "";
                 }
                 else
                 {

--- a/src/LiveSplit.Splits/UI/Components/SplitComponent.cs
+++ b/src/LiveSplit.Splits/UI/Components/SplitComponent.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.Linq;
+using System.Reflection.Emit;
 using System.Windows.Forms;
 
 using LiveSplit.Model;
@@ -18,6 +19,7 @@ public class SplitComponent : IComponent
     protected SimpleLabel NameLabel { get; set; }
     protected SimpleLabel MeasureTimeLabel { get; set; }
     protected SimpleLabel MeasureDeltaLabel { get; set; }
+    protected SimpleLabel MeasureCharLabel { get; set; }
     public SplitsSettings Settings { get; set; }
 
     protected int FrameCount { get; set; }
@@ -47,6 +49,7 @@ public class SplitComponent : IComponent
 
     public IEnumerable<ColumnData> ColumnsList { get; set; }
     public IList<SimpleLabel> LabelsList { get; set; }
+    protected List<float> ColumnWidths { get; }
 
     public float VerticalHeight { get; set; }
 
@@ -60,7 +63,7 @@ public class SplitComponent : IComponent
 
     public IDictionary<string, Action> ContextMenuControls => null;
 
-    public SplitComponent(SplitsSettings settings, IEnumerable<ColumnData> columnsList)
+    public SplitComponent(SplitsSettings settings, IEnumerable<ColumnData> columnsList, List<float> columnWidths)
     {
         NameLabel = new SimpleLabel()
         {
@@ -69,8 +72,10 @@ public class SplitComponent : IComponent
         };
         MeasureTimeLabel = new SimpleLabel();
         MeasureDeltaLabel = new SimpleLabel();
+        MeasureCharLabel = new SimpleLabel();
         Settings = settings;
         ColumnsList = columnsList;
+        ColumnWidths = columnWidths;
         TimeFormatter = new SplitTimeFormatter(Settings.SplitTimesAccuracy);
         DeltaTimeFormatter = new DeltaSplitTimeFormatter(Settings.DeltasAccuracy, Settings.DropDecimals);
         MinimumHeight = 25;
@@ -101,14 +106,18 @@ public class SplitComponent : IComponent
 
         MeasureTimeLabel.Text = TimeFormatter.Format(new TimeSpan(24, 0, 0));
         MeasureDeltaLabel.Text = DeltaTimeFormatter.Format(new TimeSpan(0, 9, 0, 0));
+        MeasureCharLabel.Text = "W";
 
         MeasureTimeLabel.Font = state.LayoutSettings.TimesFont;
         MeasureTimeLabel.IsMonospaced = true;
         MeasureDeltaLabel.Font = state.LayoutSettings.TimesFont;
         MeasureDeltaLabel.IsMonospaced = true;
+        MeasureCharLabel.Font = state.LayoutSettings.TimesFont;
+        MeasureCharLabel.IsMonospaced = true;
 
         MeasureTimeLabel.SetActualWidth(g);
         MeasureDeltaLabel.SetActualWidth(g);
+        MeasureCharLabel.SetActualWidth(g);
 
         NameLabel.ShadowColor = state.LayoutSettings.ShadowsColor;
         NameLabel.OutlineColor = state.LayoutSettings.TextOutlineColor;
@@ -229,11 +238,17 @@ public class SplitComponent : IComponent
 
             if (ColumnsList.Count() == LabelsList.Count)
             {
+                while (ColumnWidths.Count < LabelsList.Count)
+                {
+                    ColumnWidths.Add(0f);
+                }
+
                 float curX = width - 7;
                 float nameX = width - 7;
                 foreach (SimpleLabel label in LabelsList.Reverse())
                 {
-                    ColumnData column = ColumnsList.ElementAt(LabelsList.IndexOf(label));
+                    int i = LabelsList.IndexOf(label);
+                    ColumnData column = ColumnsList.ElementAt(i);
 
                     float labelWidth = 0f;
                     if (column.Type is ColumnType.DeltaorSplitTime or ColumnType.SegmentDeltaorSegmentTime)
@@ -250,8 +265,11 @@ public class SplitComponent : IComponent
                     }
                     else if (column.Type is ColumnType.CustomVariable)
                     {
-                        labelWidth = Math.Max(MeasureDeltaLabel.ActualWidth, MeasureTimeLabel.ActualWidth);
+                        labelWidth = MeasureCharLabel.ActualWidth;
                     }
+
+                    labelWidth = Math.Max(ColumnWidths[i], labelWidth);
+                    ColumnWidths[i] = labelWidth;
 
                     label.Width = labelWidth + 20;
                     curX -= labelWidth + 5;
@@ -265,6 +283,7 @@ public class SplitComponent : IComponent
                     if (!string.IsNullOrEmpty(label.Text))
                     {
                         nameX = curX + labelWidth + 5 - label.ActualWidth;
+                        ColumnWidths[i] = Math.Max(ColumnWidths[i], label.ActualWidth + 5);
                     }
                 }
 
@@ -533,14 +552,42 @@ public class SplitComponent : IComponent
     {
         if (ColumnsList != null)
         {
-            int mixedCount = ColumnsList.Count(x => x.Type is ColumnType.DeltaorSplitTime or ColumnType.SegmentDeltaorSegmentTime);
-            int deltaCount = ColumnsList.Count(x => x.Type is ColumnType.Delta or ColumnType.SegmentDelta);
-            int timeCount = ColumnsList.Count(x => x.Type is ColumnType.SplitTime or ColumnType.SegmentTime);
-            int varCount = ColumnsList.Count(x => x.Type is ColumnType.CustomVariable);
-            return (mixedCount * (Math.Max(MeasureDeltaLabel.ActualWidth, MeasureTimeLabel.ActualWidth) + 5))
-                + (deltaCount * (MeasureDeltaLabel.ActualWidth + 5))
-                + (timeCount * (MeasureTimeLabel.ActualWidth + 5))
-                + (varCount * (Math.Max(MeasureDeltaLabel.ActualWidth, MeasureTimeLabel.ActualWidth) + 5));
+            while (ColumnWidths.Count < ColumnsList.Count())
+            {
+                ColumnWidths.Add(0f);
+            }
+
+            float totalWidth = 0f;
+
+            for (int i = 0; i < ColumnsList.Count(); i++)
+            {
+                ColumnData column = ColumnsList.ElementAt(i);
+
+                float labelWidth = 0f;
+                if (column.Type is ColumnType.DeltaorSplitTime or ColumnType.SegmentDeltaorSegmentTime)
+                {
+                    labelWidth = Math.Max(MeasureDeltaLabel.ActualWidth, MeasureTimeLabel.ActualWidth);
+                }
+                else if (column.Type is ColumnType.Delta or ColumnType.SegmentDelta)
+                {
+                    labelWidth = MeasureDeltaLabel.ActualWidth;
+                }
+                else if (column.Type is ColumnType.SplitTime or ColumnType.SegmentTime)
+                {
+                    labelWidth = MeasureTimeLabel.ActualWidth;
+                }
+                else if (column.Type is ColumnType.CustomVariable)
+                {
+                    labelWidth = MeasureCharLabel.ActualWidth;
+                }
+
+                labelWidth = Math.Max(ColumnWidths[i], labelWidth);
+                ColumnWidths[i] = labelWidth;
+
+                totalWidth += labelWidth + 5;
+            }
+
+            return totalWidth;
         }
 
         return 0f;

--- a/src/LiveSplit.Splits/UI/Components/SplitComponent.cs
+++ b/src/LiveSplit.Splits/UI/Components/SplitComponent.cs
@@ -461,16 +461,8 @@ public class SplitComponent : IComponent
 
             else if (type is ColumnType.CustomVariable)
             {
-                // if the split was skipped, wipe the custom variable column entry for the split
-                if (Split.SplitTime[timingMethod] == null)
-                {
-                    label.Text = "";
-                }
-                else
-                {
-                    Split.CustomVariableValues.TryGetValue(data.Name, out string text);
-                    label.Text = text ?? "";
-                }
+                Split.CustomVariableValues.TryGetValue(data.Name, out string text);
+                label.Text = text ?? "";
             }
         }
         else

--- a/src/LiveSplit.Splits/UI/Components/SplitsComponent.cs
+++ b/src/LiveSplit.Splits/UI/Components/SplitsComponent.cs
@@ -345,7 +345,6 @@ public class SplitsComponent : IComponent
         Prepare(state);
         DrawBackground(g, width, VerticalHeight);
         SetMeasureLabels(g, state);
-        CalculateColumnWidths(state.Run);
         InternalComponent.DrawVertical(g, state, width, clipRegion);
     }
 
@@ -354,7 +353,6 @@ public class SplitsComponent : IComponent
         Prepare(state);
         DrawBackground(g, HorizontalWidth, height);
         SetMeasureLabels(g, state);
-        CalculateColumnWidths(state.Run);
         InternalComponent.DrawHorizontal(g, state, height, clipRegion);
     }
 
@@ -399,6 +397,8 @@ public class SplitsComponent : IComponent
                 SplitComponents[i].Split = state.Run.Last();
             }
         }
+
+        CalculateColumnWidths(state.Run);
 
         if (invalidator != null)
         {

--- a/src/LiveSplit.Splits/UI/Components/SplitsComponent.cs
+++ b/src/LiveSplit.Splits/UI/Components/SplitsComponent.cs
@@ -39,6 +39,7 @@ public class SplitsComponent : IComponent
     protected Color OldShadowsColor { get; set; }
 
     protected IEnumerable<ColumnData> ColumnsList => Settings.ColumnsList.Select(x => x.Data);
+    protected List<float> ColumnWidths { get; set; }
 
     public string ComponentName => "Splits";
 
@@ -61,6 +62,7 @@ public class SplitsComponent : IComponent
         visualSplitCount = Settings.VisualSplitCount;
         settingsSplitCount = Settings.VisualSplitCount;
         Settings.SplitLayoutChanged += Settings_SplitLayoutChanged;
+        ColumnWidths = Settings.ColumnsList.Select(_ => 0f).ToList();
         ScrollOffset = 0;
         RebuildVisualSplits();
         state.ComparisonRenamed += state_ComparisonRenamed;
@@ -94,7 +96,7 @@ public class SplitsComponent : IComponent
 
         if (Settings.ShowColumnLabels && CurrentState.Layout?.Mode == LayoutMode.Vertical)
         {
-            Components.Add(new LabelsComponent(Settings, ColumnsList));
+            Components.Add(new LabelsComponent(Settings, ColumnsList, ColumnWidths));
             Components.Add(new SeparatorComponent());
         }
 
@@ -113,7 +115,7 @@ public class SplitsComponent : IComponent
                 }
             }
 
-            var splitComponent = new SplitComponent(Settings, ColumnsList);
+            var splitComponent = new SplitComponent(Settings, ColumnsList, ColumnWidths);
             Components.Add(splitComponent);
             if (i < visualSplitCount - 1 || i == (Settings.LockLastSplit ? totalSplits - 1 : visualSplitCount - 1))
             {

--- a/src/LiveSplit.Splits/UI/Components/SplitsComponent.cs
+++ b/src/LiveSplit.Splits/UI/Components/SplitsComponent.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Windows.Forms;
 
 using LiveSplit.Model;
-using LiveSplit.TimeFormatters;
 
 namespace LiveSplit.UI.Components;
 
@@ -21,7 +20,6 @@ public class SplitsComponent : IComponent
 
     protected IList<IComponent> Components { get; set; }
     protected IList<SplitComponent> SplitComponents { get; set; }
-    protected IList<Dictionary<string, string>> CustomVariableValues { get; }
 
     protected SplitsSettings Settings { get; set; }
 
@@ -58,7 +56,6 @@ public class SplitsComponent : IComponent
     {
         CurrentState = state;
         Settings = new SplitsSettings(state);
-        CustomVariableValues = [];
         InternalComponent = new ComponentRendererComponent();
         ShadowImages = [];
         visualSplitCount = Settings.VisualSplitCount;
@@ -116,7 +113,7 @@ public class SplitsComponent : IComponent
                 }
             }
 
-            var splitComponent = new SplitComponent(Settings, ColumnsList, CustomVariableValues);
+            var splitComponent = new SplitComponent(Settings, ColumnsList);
             Components.Add(splitComponent);
             if (i < visualSplitCount - 1 || i == (Settings.LockLastSplit ? totalSplits - 1 : visualSplitCount - 1))
             {
@@ -341,22 +338,6 @@ public class SplitsComponent : IComponent
 
     public void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode)
     {
-        if (state.CurrentPhase is TimerPhase.Running or TimerPhase.Paused)
-        {
-            while (CustomVariableValues.Count <= state.CurrentSplitIndex)
-            {
-                CustomVariableValues.Add([]);
-            }
-
-            foreach (ColumnData column in ColumnsList)
-            {
-                if (column.Type is ColumnType.CustomVariable)
-                {
-                    CustomVariableValues[state.CurrentSplitIndex][column.Name] = state.Run.Metadata.CustomVariableValue(column.Name) ?? TimeFormatConstants.DASH;
-                }
-            }
-        }
-
         int skipCount = Math.Min(
             Math.Max(
                 0,

--- a/src/LiveSplit.Splits/UI/Components/SplitsComponent.cs
+++ b/src/LiveSplit.Splits/UI/Components/SplitsComponent.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Windows.Forms;
 
 using LiveSplit.Model;
+using LiveSplit.TimeFormatters;
 
 namespace LiveSplit.UI.Components;
 
@@ -22,6 +23,13 @@ public class SplitsComponent : IComponent
     protected IList<SplitComponent> SplitComponents { get; set; }
 
     protected SplitsSettings Settings { get; set; }
+
+    protected SimpleLabel MeasureTimeLabel { get; set; }
+    protected SimpleLabel MeasureDeltaLabel { get; set; }
+    protected SimpleLabel MeasureCharLabel { get; set; }
+
+    protected ITimeFormatter TimeFormatter { get; set; }
+    protected ITimeFormatter DeltaTimeFormatter { get; set; }
 
     private Dictionary<Image, Image> ShadowImages { get; set; }
 
@@ -58,6 +66,13 @@ public class SplitsComponent : IComponent
         CurrentState = state;
         Settings = new SplitsSettings(state);
         InternalComponent = new ComponentRendererComponent();
+
+        MeasureTimeLabel = new SimpleLabel();
+        MeasureDeltaLabel = new SimpleLabel();
+        MeasureCharLabel = new SimpleLabel();
+        TimeFormatter = new SplitTimeFormatter(Settings.SplitTimesAccuracy);
+        DeltaTimeFormatter = new DeltaSplitTimeFormatter(Settings.DeltasAccuracy, Settings.DropDecimals);
+
         ShadowImages = [];
         visualSplitCount = Settings.VisualSplitCount;
         settingsSplitCount = Settings.VisualSplitCount;
@@ -307,10 +322,29 @@ public class SplitsComponent : IComponent
         }
     }
 
+    private void SetMeasureLabels(Graphics g, LiveSplitState state)
+    {
+        MeasureTimeLabel.Text = TimeFormatter.Format(new TimeSpan(24, 0, 0));
+        MeasureDeltaLabel.Text = DeltaTimeFormatter.Format(new TimeSpan(0, 9, 0, 0));
+        MeasureCharLabel.Text = "W";
+
+        MeasureTimeLabel.Font = state.LayoutSettings.TimesFont;
+        MeasureTimeLabel.IsMonospaced = true;
+        MeasureDeltaLabel.Font = state.LayoutSettings.TimesFont;
+        MeasureDeltaLabel.IsMonospaced = true;
+        MeasureCharLabel.Font = state.LayoutSettings.TimesFont;
+        MeasureCharLabel.IsMonospaced = true;
+
+        MeasureTimeLabel.SetActualWidth(g);
+        MeasureDeltaLabel.SetActualWidth(g);
+        MeasureCharLabel.SetActualWidth(g);
+    }
+
     public void DrawVertical(Graphics g, LiveSplitState state, float width, Region clipRegion)
     {
         Prepare(state);
         DrawBackground(g, width, VerticalHeight);
+        SetMeasureLabels(g, state);
         InternalComponent.DrawVertical(g, state, width, clipRegion);
     }
 
@@ -318,6 +352,7 @@ public class SplitsComponent : IComponent
     {
         Prepare(state);
         DrawBackground(g, HorizontalWidth, height);
+        SetMeasureLabels(g, state);
         InternalComponent.DrawHorizontal(g, state, height, clipRegion);
     }
 
@@ -363,9 +398,56 @@ public class SplitsComponent : IComponent
             }
         }
 
+        CalculateColumnWidths(state.Run);
+
         if (invalidator != null)
         {
             InternalComponent.Update(invalidator, state, width, height, mode);
+        }
+    }
+
+    private void CalculateColumnWidths(IRun run)
+    {
+        if (ColumnsList != null)
+        {
+            while (ColumnWidths.Count < ColumnsList.Count())
+            {
+                ColumnWidths.Add(0f);
+            }
+
+            for (int i = 0; i < ColumnsList.Count(); i++)
+            {
+                ColumnData column = ColumnsList.ElementAt(i);
+
+                float labelWidth = 0f;
+                if (column.Type is ColumnType.DeltaorSplitTime or ColumnType.SegmentDeltaorSegmentTime)
+                {
+                    labelWidth = Math.Max(MeasureDeltaLabel.ActualWidth, MeasureTimeLabel.ActualWidth);
+                }
+                else if (column.Type is ColumnType.Delta or ColumnType.SegmentDelta)
+                {
+                    labelWidth = MeasureDeltaLabel.ActualWidth;
+                }
+                else if (column.Type is ColumnType.SplitTime or ColumnType.SegmentTime)
+                {
+                    labelWidth = MeasureTimeLabel.ActualWidth;
+                }
+                else if (column.Type is ColumnType.CustomVariable)
+                {
+                    int longest_length = run.Metadata.CustomVariableValue(column.Name).Length;
+                    foreach (ISegment split in run)
+                    {
+                        if (split.CustomVariableValues.TryGetValue(column.Name, out string value) && !string.IsNullOrEmpty(value))
+                        {
+                            longest_length = Math.Max(longest_length, value.Length);
+                        }
+                    }
+
+                    labelWidth = MeasureCharLabel.ActualWidth * longest_length;
+                }
+
+                ColumnWidths[i] = labelWidth;
+            }
         }
     }
 

--- a/src/LiveSplit.Splits/UI/Components/SplitsComponent.cs
+++ b/src/LiveSplit.Splits/UI/Components/SplitsComponent.cs
@@ -345,6 +345,7 @@ public class SplitsComponent : IComponent
         Prepare(state);
         DrawBackground(g, width, VerticalHeight);
         SetMeasureLabels(g, state);
+        CalculateColumnWidths(state.Run);
         InternalComponent.DrawVertical(g, state, width, clipRegion);
     }
 
@@ -353,6 +354,7 @@ public class SplitsComponent : IComponent
         Prepare(state);
         DrawBackground(g, HorizontalWidth, height);
         SetMeasureLabels(g, state);
+        CalculateColumnWidths(state.Run);
         InternalComponent.DrawHorizontal(g, state, height, clipRegion);
     }
 
@@ -397,8 +399,6 @@ public class SplitsComponent : IComponent
                 SplitComponents[i].Split = state.Run.Last();
             }
         }
-
-        CalculateColumnWidths(state.Run);
 
         if (invalidator != null)
         {


### PR DESCRIPTION
A companion PR to https://github.com/LiveSplit/LiveSplit/pull/2528. Allows a column in the splits component to display the value of a Custom Variable, with Column Type choice option.

Depends on https://github.com/LiveSplit/LiveSplit/pull/2600.

Tasks:
- [x] Test behavior on skipped splits. If different from LiveSplit One, fix it to match.
  - After `wipe custom variable column for skipped splits`, when a split is skipped, both wipe the variable entries for that split
- [x] Fix behavior when splits scroll up and down.
- [x] Make sure past segment custom variable values are preserved when switching layouts, and show as the normal text color, not black