### PR TITLE
Add GlobalFontConsumer attribute for per-component font override support

### DIFF
--- a/src/LiveSplit.Splits/UI/Components/LabelsComponent.cs
+++ b/src/LiveSplit.Splits/UI/Components/LabelsComponent.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
@@ -9,6 +9,7 @@ using LiveSplit.Model.Comparisons;
 
 namespace LiveSplit.UI.Components;
 
+[GlobalFontConsumer(GlobalFont.TextFont)]
 public class LabelsComponent : IComponent
 {
     public SplitsSettings Settings { get; set; }

--- a/src/LiveSplit.Splits/UI/Components/SplitComponent.cs
+++ b/src/LiveSplit.Splits/UI/Components/SplitComponent.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
@@ -11,6 +11,7 @@ using LiveSplit.TimeFormatters;
 
 namespace LiveSplit.UI.Components;
 
+[GlobalFontConsumer(GlobalFont.TimesFont | GlobalFont.TextFont)]
 public class SplitComponent : IComponent
 {
     public ISegment Split { get; set; }

--- a/src/LiveSplit.Splits/UI/Components/SplitsComponent.cs
+++ b/src/LiveSplit.Splits/UI/Components/SplitsComponent.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
@@ -10,6 +10,7 @@ using LiveSplit.TimeFormatters;
 
 namespace LiveSplit.UI.Components;
 
+[GlobalFontConsumer(GlobalFont.TimesFont)]
 public class SplitsComponent : IComponent
 {
     public ComponentRendererComponent InternalComponent { get; protected set; }


### PR DESCRIPTION
## Summary
- Add `[GlobalFontConsumer]` attribute to declare which global fonts the component uses
- Enables the per-component font override system introduced in LiveSplit/LiveSplit#2688