### PR TITLE
Fill remaining Chinese Splits translations

### DIFF
--- a/src/LiveSplit.Splits/UI/Components/ColumnSettings.cs
+++ b/src/LiveSplit.Splits/UI/Components/ColumnSettings.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
 
+using LiveSplit.Localization;
 using LiveSplit.Model;
 using LiveSplit.Model.Comparisons;
 
@@ -10,6 +11,8 @@ namespace LiveSplit.UI.Components;
 
 public partial class ColumnSettings : UserControl
 {
+    private static string T(string source) => UiLocalizer.Translate(source, LanguageResolver.ResolveCurrentCultureLanguage());
+
     public string ColumnName { get => Data.Name; set => Data.Name = value; }
     public string Type
     {
@@ -61,6 +64,11 @@ public partial class ColumnSettings : UserControl
 
     private void ColumnSettings_Load(object sender, EventArgs e)
     {
+        if (string.Equals(ColumnName, "Time", StringComparison.Ordinal))
+        {
+            ColumnName = T("Time");
+        }
+
         UpdateComparisonItems();
 
         txtName.DataBindings.Clear();
@@ -69,6 +77,7 @@ public partial class ColumnSettings : UserControl
         txtName.DataBindings.Add("Text", this, "ColumnName", false, DataSourceUpdateMode.OnPropertyChanged);
         cmbColumnType.DataBindings.Add("SelectedItem", this, "Type", false, DataSourceUpdateMode.OnPropertyChanged);
         cmbTimingMethod.DataBindings.Add("SelectedItem", this, "TimingMethod", false, DataSourceUpdateMode.OnPropertyChanged);
+        txtName_TextChanged(null, EventArgs.Empty);
     }
 
     public void UpdateEnabledButtons()
@@ -79,7 +88,7 @@ public partial class ColumnSettings : UserControl
 
     private void txtName_TextChanged(object sender, EventArgs e)
     {
-        groupColumn.Text = $"Column: {txtName.Text}";
+        groupColumn.Text = string.Format(T("Column: {0}"), txtName.Text);
     }
 
     private void UpdateComparisonItems()

--- a/src/LiveSplit.Splits/UI/Components/SplitsSettings.cs
+++ b/src/LiveSplit.Splits/UI/Components/SplitsSettings.cs
@@ -175,7 +175,7 @@ public partial class SplitsSettings : UserControl
 
         ColumnsList = [];
         ColumnsList.Add(new ColumnSettings(CurrentState, "+/-", ColumnsList) { Data = new ColumnData("+/-", ColumnType.Delta, "Current Comparison", "Current Timing Method") });
-        ColumnsList.Add(new ColumnSettings(CurrentState, "Time", ColumnsList) { Data = new ColumnData("Time", ColumnType.SplitTime, "Current Comparison", "Current Timing Method") });
+        ColumnsList.Add(new ColumnSettings(CurrentState, T("Time"), ColumnsList) { Data = new ColumnData(T("Time"), ColumnType.SplitTime, "Current Comparison", "Current Timing Method") });
 
         StartingColumnSettingHeight = ColumnsList[0].Height;
     }


### PR DESCRIPTION
## Summary
- localize the runtime-generated `Column` group title in the Splits settings UI
- localize the default `Time` column name in the Splits settings UI
- keep the follow-up scoped to the remaining Simplified Chinese gaps reported after the earlier UI localization work landed

## Context
This is a follow-up to the remaining translation gaps reported after `#2676` landed. In particular, the Splits settings page still had untranslated runtime-generated labels such as `Column: Time`, along with comparison entries like `Personal Best` and `Average Segments` showing through in English.

## Validation
- `dotnet build src/LiveSplit.Splits/LiveSplit.Splits.csproj -c Release`
